### PR TITLE
Remove multiple quotes from cli arguments

### DIFF
--- a/powershell.go
+++ b/powershell.go
@@ -64,7 +64,9 @@ func BuildPowershellType(value string) interface{} {
 		return ConvertPowershellArray(value)
 	} else {
 		value = strings.Trim(value, "\"")
-		if value[0] == '\'' && value[len(value)-1] == '\'' {
+		if len(value) >= 6 && value[0:4] == "'\\''" && value[len(value)-4:] == "'\\''" {
+			return value[4 : len(value)-4]
+		} else if value[0] == '\'' && value[len(value)-1] == '\'' {
 			return value[1 : len(value)-1]
 		}
 		return value

--- a/powershell.go
+++ b/powershell.go
@@ -63,6 +63,10 @@ func BuildPowershellType(value string) interface{} {
 	} else if IsPowershellArray(value) {
 		return ConvertPowershellArray(value)
 	} else {
+		value = strings.Trim(value, "\"")
+		if value[0] == '\'' && value[len(value)-1] == '\'' {
+			return value[1: len(value)-1]
+		}
 		return value
 	}
 }

--- a/powershell.go
+++ b/powershell.go
@@ -41,8 +41,10 @@ func GetPowershellArgs(args []string) (command string, arguments map[string]inte
 			// next argument is also a flag, so this is a switch
 			arguments[arg] = true
 		} else {
+
 			arguments[arg] = BuildPowershellType(args[i+1])
 			i++
+
 		}
 	}
 
@@ -65,7 +67,7 @@ func BuildPowershellType(value string) interface{} {
 	} else {
 		value = strings.Trim(value, "\"")
 		if value[0] == '\'' && value[len(value)-1] == '\'' {
-			return value[1: len(value)-1]
+			return value[1 : len(value)-1]
 		}
 		return value
 	}
@@ -74,9 +76,10 @@ func BuildPowershellType(value string) interface{} {
 // ConvertPowershellArray to a golang type.
 //
 // Examples:
-//  @() -> []string{}
-//  @('abc') -> []string{"abc"}
-//  @('abc','def') -> []string{"abc","def"}
+//
+//	@() -> []string{}
+//	@('abc') -> []string{"abc"}
+//	@('abc','def') -> []string{"abc","def"}
 //
 // nolint:funlen
 func ConvertPowershellArray(value string) []string {
@@ -177,11 +180,10 @@ func unquoteString(s string) string {
 //
 // Examples:
 //
-//  try { Use-Icinga -Minimal; } catch { <# something #> exit 3; };
-// 	  Exit-IcingaExecutePlugin -Command 'Invoke-IcingaCheckUsedPartitionSpace'
-//  try { Use-Icinga -Minimal; } catch { <# something #> exit 3; }; Invoke-IcingaCheckUsedPartitionSpace
-//  Invoke-IcingaCheckUsedPartitionSpace
-//
+//	 try { Use-Icinga -Minimal; } catch { <# something #> exit 3; };
+//		  Exit-IcingaExecutePlugin -Command 'Invoke-IcingaCheckUsedPartitionSpace'
+//	 try { Use-Icinga -Minimal; } catch { <# something #> exit 3; }; Invoke-IcingaCheckUsedPartitionSpace
+//	 Invoke-IcingaCheckUsedPartitionSpace
 func ParsePowershellTryCatch(command string) string {
 	command = strings.TrimSpace(command)
 

--- a/powershell.go
+++ b/powershell.go
@@ -41,10 +41,8 @@ func GetPowershellArgs(args []string) (command string, arguments map[string]inte
 			// next argument is also a flag, so this is a switch
 			arguments[arg] = true
 		} else {
-
 			arguments[arg] = BuildPowershellType(args[i+1])
 			i++
-
 		}
 	}
 

--- a/powershell_test.go
+++ b/powershell_test.go
@@ -107,8 +107,10 @@ func TestPowershellQuotes2(t *testing.T) {
 	command, arguments := GetPowershellArgs([]string{"-Command", "Invoke-IcingaCheckCPU", "-Core", `'\''_Total'\''`})
 
 	assert.Equal(t, "Invoke-IcingaCheckCPU", command)
+
 	expected_args := map[string]interface{}{
 		"-Core": "_Total",
 	}
+
 	assert.Equal(t, expected_args, arguments)
 }

--- a/powershell_test.go
+++ b/powershell_test.go
@@ -85,7 +85,14 @@ func TestParsePowershellTryCatch(t *testing.T) {
 }
 
 func TestPowershellQuotes(t *testing.T) {
-	command, arguments := GetPowershellArgs([]string{"-Command", "Invoke-IcingaCheckPerfCounter", "-PerfCounter", `"'\TCPv4\Connections Established'"`})
+	command, arguments := GetPowershellArgs(
+		[]string{
+			"-Command",
+			"Invoke-IcingaCheckPerfCounter",
+			"-PerfCounter",
+			`"'\TCPv4\Connections Established'"`,
+		},
+	)
 
 	assert.Equal(t, "Invoke-IcingaCheckPerfCounter", command)
 

--- a/powershell_test.go
+++ b/powershell_test.go
@@ -88,8 +88,10 @@ func TestPowershellQuotes(t *testing.T) {
 	command, arguments := GetPowershellArgs([]string{"-Command", "Invoke-IcingaCheckPerfCounter", "-PerfCounter", `"'\TCPv4\Connections Established'"`})
 
 	assert.Equal(t, "Invoke-IcingaCheckPerfCounter", command)
+
 	expected_args := map[string]interface{}{
 		"-PerfCounter": "\\TCPv4\\Connections Established",
 	}
+
 	assert.Equal(t, expected_args, arguments)
 }

--- a/powershell_test.go
+++ b/powershell_test.go
@@ -83,3 +83,13 @@ func TestParsePowershellTryCatch(t *testing.T) {
 	command = ParsePowershellTryCatch("Invoke-IcingaCheckUsedPartitionSpace")
 	assert.Equal(t, "Invoke-IcingaCheckUsedPartitionSpace", command)
 }
+
+func TestPowershellQuotes(t *testing.T) {
+	command, arguments := GetPowershellArgs([]string{"-Command", "Invoke-IcingaCheckPerfCounter", "-PerfCounter", `"'\TCPv4\Connections Established'"`})
+
+	assert.Equal(t, "Invoke-IcingaCheckPerfCounter", command)
+	expected_args := map[string]interface{}{
+		"-PerfCounter": "\\TCPv4\\Connections Established",
+	}
+	assert.Equal(t, expected_args, arguments)
+}

--- a/powershell_test.go
+++ b/powershell_test.go
@@ -102,3 +102,13 @@ func TestPowershellQuotes(t *testing.T) {
 
 	assert.Equal(t, expected_args, arguments)
 }
+
+func TestPowershellQuotes2(t *testing.T) {
+	command, arguments := GetPowershellArgs([]string{"-Command", "Invoke-IcingaCheckCPU", "-Core", `'\''_Total'\''`})
+
+	assert.Equal(t, "Invoke-IcingaCheckCPU", command)
+	expected_args := map[string]interface{}{
+		"-Core": "_Total",
+	}
+	assert.Equal(t, expected_args, arguments)
+}


### PR DESCRIPTION
For some weird reason the IfW-Plugins definition in Icinga2 may generate arguments of the form `"'blafoo'"` and the `'` are not stripped, but passed on, which crashes some checks.
This change removes those inner quotes also.