### PR TITLE
PS-Parser: Warning and Critical may have range expressions

### DIFF
--- a/powershell.go
+++ b/powershell.go
@@ -37,15 +37,15 @@ func GetPowershellArgs(args []string) (command string, arguments map[string]inte
 		}
 
 		// warning and critical might be ranges
-		if strings.ToLower(arg) ==  "-warning" || strings.ToLower(arg) ==  "-critical" {
+		if strings.ToLower(arg) == "-warning" || strings.ToLower(arg) == "-critical" {
 			// No matter what happens, the next argument is a threshold value
 			// This is a dirty hack to allow the usage of range expressions which might
 			// begin with '-' (which then might be interpreted as options
 			arguments[arg] = BuildPowershellType(args[i+1])
 			i++
+
 			continue
 		}
-
 
 		// all other flags
 		if i+1 >= l || args[i+1][0] == '-' {
@@ -81,9 +81,10 @@ func BuildPowershellType(value string) interface{} {
 // ConvertPowershellArray to a golang type.
 //
 // Examples:
-//  @() -> []string{}
-//  @('abc') -> []string{"abc"}
-//  @('abc','def') -> []string{"abc","def"}
+//
+//	@() -> []string{}
+//	@('abc') -> []string{"abc"}
+//	@('abc','def') -> []string{"abc","def"}
 //
 // nolint:funlen
 func ConvertPowershellArray(value string) []string {
@@ -184,11 +185,10 @@ func unquoteString(s string) string {
 //
 // Examples:
 //
-//  try { Use-Icinga -Minimal; } catch { <# something #> exit 3; };
-// 	  Exit-IcingaExecutePlugin -Command 'Invoke-IcingaCheckUsedPartitionSpace'
-//  try { Use-Icinga -Minimal; } catch { <# something #> exit 3; }; Invoke-IcingaCheckUsedPartitionSpace
-//  Invoke-IcingaCheckUsedPartitionSpace
-//
+//	 try { Use-Icinga -Minimal; } catch { <# something #> exit 3; };
+//		  Exit-IcingaExecutePlugin -Command 'Invoke-IcingaCheckUsedPartitionSpace'
+//	 try { Use-Icinga -Minimal; } catch { <# something #> exit 3; }; Invoke-IcingaCheckUsedPartitionSpace
+//	 Invoke-IcingaCheckUsedPartitionSpace
 func ParsePowershellTryCatch(command string) string {
 	command = strings.TrimSpace(command)
 

--- a/powershell.go
+++ b/powershell.go
@@ -36,6 +36,17 @@ func GetPowershellArgs(args []string) (command string, arguments map[string]inte
 			continue
 		}
 
+		// warning and critical might be ranges
+		if strings.ToLower(arg) ==  "-warning" || strings.ToLower(arg) ==  "-critical" {
+			// No matter what happens, the next argument is a threshold value
+			// This is a dirty hack to allow the usage of range expressions which might
+			// begin with '-' (which then might be interpreted as options
+			arguments[arg] = BuildPowershellType(args[i+1])
+			i++
+			continue
+		}
+
+
 		// all other flags
 		if i+1 >= l || args[i+1][0] == '-' {
 			// next argument is also a flag, so this is a switch

--- a/powershell_test.go
+++ b/powershell_test.go
@@ -47,6 +47,12 @@ func TestGetPowershellArgs(t *testing.T) {
 	}, args)
 }
 
+func TestPowershellRangeExpression(t *testing.T) {
+	command, args := GetPowershellArgs([]string{"-C", "Invoke-IcingaCheckUsedPartitionSpace", "-Warning", "-5:80"})
+	assert.Equal(t, "Invoke-IcingaCheckUsedPartitionSpace", command)
+	assert.Equal(t, map[string]interface{}{"-Warning": "-5:80"}, args)
+}
+
 func TestPowershellArrayConversionEmpty(t *testing.T) {
 	assert.Equal(t, []string{}, ConvertPowershellArray("@()"))
 	assert.Equal(t, []string{}, ConvertPowershellArray(""))


### PR DESCRIPTION
Some arguments may accept range expressions as values. Since those may begin with negative numerical values (e.g. '-5:200') they were interpreted as options and the warning and critical options as switches.

Since the powershell-connector has no way to know which arguments may accept range expressions, I just hardcoded warning and critical for now.