### PR TITLE
Add benchmark for powershell parser and extend tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,4 +13,5 @@ powershell-connector*
 # Test files
 *.crt
 *.out
+*.profile
 coverage.html

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,5 +1,7 @@
 run:
-  deadline: 1m
+  timeout: 5m
+  skip-files:
+    - '(.+)_test\.go'
 
 linters:
   disable-all: false

--- a/api_test.go
+++ b/api_test.go
@@ -1,0 +1,56 @@
+package main
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+type ApiTest struct {
+	name     string
+	server   *httptest.Server
+	api      RestAPI
+	expected APICheckResult
+}
+
+func TestApiCmd(t *testing.T) {
+	tests := []ApiTest{
+		{
+			name: "api-simple-test",
+			server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusOK)
+				w.Write([]byte(`{"Invoke-IcingaCheckFoo": {"exitcode": 0, "checkresult": "[OK] \"foo\"", "perfdata": ["'foo'=1.00%;;;0;100 "]}}`))
+			})),
+			api: RestAPI{},
+			expected: APICheckResult{
+				ExitCode:    0,
+				CheckResult: "[OK] \"foo\"",
+				Perfdata:    APIPerfdataList{},
+			},
+		},
+	}
+
+	var (
+		actual *APICheckResult
+		err    error
+	)
+
+	args := make(map[string]interface{})
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			defer test.server.Close()
+			test.api.URL = test.server.URL
+
+			actual, err = test.api.ExecuteCheck("command", args, 10)
+
+			if err != nil {
+				t.Error(err)
+			}
+
+			if actual.CheckResult != test.expected.CheckResult {
+				t.Error("\nActual: ", actual.CheckResult, "\nExpected: ", test.expected.CheckResult)
+			}
+		})
+	}
+}

--- a/netstring_test.go
+++ b/netstring_test.go
@@ -1,16 +1,14 @@
 package main
 
 import (
-	"github.com/stretchr/testify/assert"
-	"os"
+	"strings"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestParseNetstring(t *testing.T) {
-	r, err := os.Open("testdata/netstring.dat")
-	if err != nil {
-		t.Fatal(err)
-	}
+	r := strings.NewReader("1:a,5:bbbbb,11:aaaaaaaaaaa,")
 
 	data, err := ParseNetstring(r)
 	assert.NoError(t, err)

--- a/powershell.go
+++ b/powershell.go
@@ -68,15 +68,17 @@ func BuildPowershellType(value string) interface{} {
 		return false
 	} else if IsPowershellArray(value) {
 		return ConvertPowershellArray(value)
-	} else {
-		value = strings.Trim(value, "\"")
-		if len(value) >= 6 && value[0:4] == "'\\''" && value[len(value)-4:] == "'\\''" {
-			return value[4 : len(value)-4]
-		} else if value[0] == '\'' && value[len(value)-1] == '\'' {
-			return value[1 : len(value)-1]
-		}
-		return value
 	}
+
+	value = strings.Trim(value, "\"")
+
+	if len(value) >= 6 && value[0:4] == "'\\''" && value[len(value)-4:] == "'\\''" {
+		return value[4 : len(value)-4]
+	} else if value[0] == '\'' && value[len(value)-1] == '\'' {
+		return value[1 : len(value)-1]
+	}
+
+	return value
 }
 
 // ConvertPowershellArray to a golang type.

--- a/powershell.go
+++ b/powershell.go
@@ -1,12 +1,7 @@
 package main
 
 import (
-	"regexp"
 	"strings"
-)
-
-var (
-	reUnquoteString = regexp.MustCompile(`(^["'\s]+|["'\s]+$)`)
 )
 
 // GetPowershellArgs returns remaining args and parse them as if we were powershell.exe
@@ -192,18 +187,15 @@ func unquoteString(s string) string {
 // Examples:
 //
 //	 try { Use-Icinga -Minimal; } catch { <# something #> exit 3; };
-//		  Exit-IcingaExecutePlugin -Command 'Invoke-IcingaCheckUsedPartitionSpace'
+//			Exit-IcingaExecutePlugin -Command 'Invoke-IcingaCheckUsedPartitionSpace'
 //	 try { Use-Icinga -Minimal; } catch { <# something #> exit 3; }; Invoke-IcingaCheckUsedPartitionSpace
 //	 Invoke-IcingaCheckUsedPartitionSpace
 func ParsePowershellTryCatch(command string) string {
 	command = strings.TrimSpace(command)
-
-	// for now just parse the last word, dequote it and use it as command
+	// For now just parse the last word, dequote it and use it as command
 	parts := strings.Split(command, " ")
-	command = parts[len(parts)-1]
-	command = reUnquoteString.ReplaceAllString(command, "")
-
-	return command
+	// Trim ' " and whitespaces
+	return strings.Trim(parts[len(parts)-1], "'\" \t")
 }
 
 func IsPowershellArray(s string) bool {

--- a/powershell_test.go
+++ b/powershell_test.go
@@ -6,6 +6,31 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func BenchmarkGetPowershellArgs(b *testing.B) {
+	b.ReportAllocs()
+
+	for i := 0; i < b.N; i++ {
+		GetPowershellArgs([]string{
+			"--powershell-api",
+			"https://battlestation:5668",
+			"--powershell-insecure",
+			"-C",
+			"try { Use-Icinga -Minimal; } catch { <# some error #>; exit 3; }; " +
+				"Exit-IcingaExecutePlugin -Command 'Invoke-IcingaCheckUsedPartitionSpace' ",
+			"-Warning",
+			"80",
+			"-Critical",
+			"95",
+			"-Include",
+			"@()",
+			"-Exclude",
+			"@('abc','def')",
+			"-Verbosity",
+			"2",
+		})
+	}
+}
+
 func TestGetPowershellArgs(t *testing.T) {
 	command, args := GetPowershellArgs([]string{"-C", "Invoke-IcingaCheckUsedPartitionSpace", "-Warning", "80"})
 	assert.Equal(t, "Invoke-IcingaCheckUsedPartitionSpace", command)

--- a/powershell_test.go
+++ b/powershell_test.go
@@ -113,6 +113,24 @@ func TestParsePowershellTryCatch(t *testing.T) {
 
 	command = ParsePowershellTryCatch("Invoke-IcingaCheckUsedPartitionSpace")
 	assert.Equal(t, "Invoke-IcingaCheckUsedPartitionSpace", command)
+
+	command = ParsePowershellTryCatch("   'Invoke-IcingaCheckUsedPartitionSpace'  ")
+	assert.Equal(t, "Invoke-IcingaCheckUsedPartitionSpace", command)
+
+	command = ParsePowershellTryCatch("   'Invoke-IcingaCheckUsedPartitionSpace'  ")
+	assert.Equal(t, "Invoke-IcingaCheckUsedPartitionSpace", command)
+
+	command = ParsePowershellTryCatch("try catch foo bar   'Invoke-IcingaCheckUsedPartitionSpace'")
+	assert.Equal(t, "Invoke-IcingaCheckUsedPartitionSpace", command)
+
+	command = ParsePowershellTryCatch("Exit-Foo -Test \"'Invoke-IcingaCheckUsedPartitionSpace'\"")
+	assert.Equal(t, "Invoke-IcingaCheckUsedPartitionSpace", command)
+
+	command = ParsePowershellTryCatch("")
+	assert.Equal(t, "", command)
+
+	command = ParsePowershellTryCatch("foo")
+	assert.Equal(t, "foo", command)
 }
 
 func TestPowershellQuotes(t *testing.T) {

--- a/testdata/netstring.dat
+++ b/testdata/netstring.dat
@@ -1,1 +1,0 @@
-1:a,5:bbbbb,11:aaaaaaaaaaa,


### PR DESCRIPTION
Tried to optimize some functions

Before:
```
pkg: github.com/NETWAYS/icinga-powershell-connector
cpu: 11th Gen Intel(R) Core(TM) i7-1165G7 @ 2.80GHz
BenchmarkGetPowershellArgs-8   	  444860	      2591 ns/op	     988 B/op	      22 allocs/op
BenchmarkGetPowershellArgs-8   	  479780	      2557 ns/op	     988 B/op	      22 allocs/op
BenchmarkGetPowershellArgs-8   	  423138	      2580 ns/op	     988 B/op	      22 allocs/op
```

After:
```
pkg: github.com/NETWAYS/icinga-powershell-connector
cpu: 11th Gen Intel(R) Core(TM) i7-1165G7 @ 2.80GHz
BenchmarkGetPowershellArgs-8   	  968371	      1107 ns/op	     872 B/op	      19 allocs/op
BenchmarkGetPowershellArgs-8   	  967675	      1096 ns/op	     872 B/op	      19 allocs/op
BenchmarkGetPowershellArgs-8   	  955102	      1091 ns/op	     872 B/op	      19 allocs/op

GetPowershellArgs-8        2.586µ ± 1%   1.106µ ± 1%  -57.22% (p=0.000 n=12)
```