### PR TITLE
Add custom error message for http timeouts

### DIFF
--- a/api.go
+++ b/api.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -46,8 +47,13 @@ func (a RestAPI) ExecuteCheck(command string, arguments map[string]interface{}, 
 
 	// Execute request
 	resp, err := a.getClient().Do(req)
+
 	if err != nil {
-		return nil, fmt.Errorf("API request failed: %w", err)
+		// We want to override the context error message to be more expressive
+		if errors.Is(err, context.DeadlineExceeded) {
+			return nil, fmt.Errorf("timeout during HTTP request: %w", err)
+		}
+		return nil, fmt.Errorf("executing API request failed: %w", err)
 	}
 
 	defer resp.Body.Close()

--- a/config.go
+++ b/config.go
@@ -52,7 +52,7 @@ func (c *Config) BuildFlags(fs *flag.FlagSet) {
 	fs.BoolVar(&c.Insecure, "insecure", c.Insecure, "Ignore any certificate checks")
 	fs.BoolVar(&c.Debug, "debug", c.Debug, "Enable debug logging")
 	fs.BoolVar(&c.PrintVersion, "version", false, "Print program version")
-	fs.Uint32Var(&c.Timeout, "timeout", 10, "Powershell connector timeout")
+	fs.Uint32Var(&c.Timeout, "timeout", 10, "Powershell connector timeout in seconds")
 }
 
 // ParseConfigFromFlags to be called to parse CLI arguments and return the built Config struct.


### PR DESCRIPTION
- Overrides the error from the context package, so that non-Gophers know what's happening.

Fixes #9 